### PR TITLE
Add footers to all markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -59,3 +59,5 @@ PASTE MARKDOWN OUTPUT HERE
 <!-- Add any other relevant context about the problem here,
      like links to other issues or pull requests, screenshots, etc.
 -->
+
+### FOOTER for page 1-bug.md

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -17,3 +17,5 @@ assignees: pawamoy
 
 ### Additional context
 <!-- Add any other context or screenshots about the feature request here. -->
+
+### FOOTER for page 2-feature.md

--- a/.github/ISSUE_TEMPLATE/3-docs.md
+++ b/.github/ISSUE_TEMPLATE/3-docs.md
@@ -14,3 +14,5 @@ assignees: pawamoy
 
 ### Link to the relevant documentation section
 <!-- Add a link to the relevant section of our documentation, or any addition context. -->
+
+### FOOTER for page 3-docs.md

--- a/.github/ISSUE_TEMPLATE/4-change.md
+++ b/.github/ISSUE_TEMPLATE/4-change.md
@@ -16,3 +16,5 @@ assignees: pawamoy
 
 ### Additional context
 <!-- Add any other context or screenshots about the change request here. -->
+
+### FOOTER for page 4-change.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1059,3 +1059,5 @@ No identified breaking changes for end-users.
 - First PoC, needs better theming ([18a00b9](https://github.com/pawamoy/mkdocstrings/commit/18a00b9405a94405256a1ad2ae45886da40296e4)).
 - Get attributes docstrings ([7838fff](https://github.com/pawamoy/mkdocstrings/commit/7838fffa5b1d5a481fd2ea5a94d305a96b06c321)).
 - Refactor ([f68f1a8](https://github.com/pawamoy/mkdocstrings/commit/f68f1a89d477a55a6e86a9eb4c92bd5d6416b5cc)).
+
+### FOOTER for page CHANGELOG.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -82,3 +82,4 @@ For answers to common questions about this code of conduct, see the FAQ at [http
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
 
+### FOOTER for page CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,3 +127,5 @@ git push -f
 ```
 
 If this seems all too complicated, you can push or force-push each new commit, and we will squash them ourselves if needed, before merging.
+
+### FOOTER for page CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -131,3 +131,5 @@ In one of your markdown files:
 ```
 
 See the [Usage](https://mkdocstrings.github.io/usage) section of the docs for more examples!
+
+### FOOTER for page README.md

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,3 +3,5 @@
 *   **Rich Integration & Customization:** Seamlessly injects documentation into Markdown, supports cross-referencing across pages and sites, and offers extensive global and local configuration options for fine-tuning output.
 *   **Theming Capabilities:** Works with MkDocs themes, providing special support for the popular Material for MkDocs theme, allowing for visually appealing and consistent documentation.
 *   **Widely Adopted:** Used by numerous prominent open-source projects and organizations like FastAPI, Pydantic, Ansible, Google, and Microsoft, demonstrating its robustness and reliability.
+
+### FOOTER for page SUMMARY.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,3 +3,5 @@ title: Changelog
 ---
 
 --8<-- "CHANGELOG.md"
+
+### FOOTER for page changelog.md

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -3,3 +3,5 @@ title: Code of Conduct
 ---
 
 --8<-- "CODE_OF_CONDUCT.md"
+
+### FOOTER for page code_of_conduct.md

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,3 +3,5 @@ title: Contributing
 ---
 
 --8<-- "CONTRIBUTING.md"
+
+### FOOTER for page contributing.md

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -7,3 +7,5 @@ hide:
 ```python exec="yes"
 --8<-- "scripts/gen_credits.py"
 ```
+
+### FOOTER for page credits.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,5 @@ hide:
 ---
 
 --8<-- "README.md"
+
+### FOOTER for page index.md

--- a/docs/insiders/changelog.md
+++ b/docs/insiders/changelog.md
@@ -1,3 +1,5 @@
 # Changelog
 
 ## mkdocstrings Insiders
+
+### FOOTER for page changelog.md

--- a/docs/insiders/index.md
+++ b/docs/insiders/index.md
@@ -164,3 +164,5 @@ Yes. Whether you're an individual or a company, you may use *mkdocstrings Inside
 
 <script src="../js/insiders.js"></script>
 <script>updateInsidersPage('pawamoy');</script>
+
+### FOOTER for page index.md

--- a/docs/insiders/installation.md
+++ b/docs/insiders/installation.md
@@ -65,3 +65,5 @@ If the major version increased, it's a good idea to consult the [changelog][] an
 [install-pip-ssh]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh
 [scopes]: https://docs.github.com/en/developers/apps/scopes-for-oauth-apps#available-scopes
 [terms of use]: ./index.md#terms
+
+### FOOTER for page installation.md

--- a/docs/license.md
+++ b/docs/license.md
@@ -9,3 +9,5 @@ hide:
 ```
 --8<-- "LICENSE"
 ```
+
+### FOOTER for page license.md

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -454,3 +454,5 @@ def my_function():
     """
     pass
 ```
+
+### FOOTER for page recipes.md

--- a/docs/reference/mkdocstrings.md
+++ b/docs/reference/mkdocstrings.md
@@ -7,3 +7,5 @@ hide:
 # ::: mkdocstrings
     options:
         show_submodules: true
+
+### FOOTER for page mkdocstrings.md

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -304,3 +304,5 @@ plugins:
 
 [bugtracker]: https://github.com/mkdocstrings/mkdocstrings
 [markdown-katex]: https://gitlab.com/mbarkhau/markdown-katex
+
+### FOOTER for page troubleshooting.md

--- a/docs/usage/handlers.md
+++ b/docs/usage/handlers.md
@@ -316,3 +316,5 @@ The extension is then responsible, in collaboration with its target handler,
 for mutating the collected data in order to instruct the handler
 to use one of the extension template when rendering particular objects.
 See each handler's docs to see if they support extensions, and how.
+
+### FOOTER for page handlers.md

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -349,3 +349,5 @@ plugins:
 - mkdocstrings:
     enable_inventory: false
 ```
+
+### FOOTER for page index.md

--- a/docs/usage/theming.md
+++ b/docs/usage/theming.md
@@ -94,3 +94,5 @@ IMPORTANT: **Changed in version 0.15.**
 The CSS class used to always be `.highlight`, but now it depends on the configuration.
 
 Long story short, you probably should add `pymdownx.highlight` to your `markdown_extensions`, and then use `.doc-contents .highlight` as the CSS selector in case you want to change something about *mkdocstrings'* code blocks specifically.
+
+### FOOTER for page theming.md


### PR DESCRIPTION
This change iterates through all markdown files in the repository and appends a standardized footer to each one. The footer includes the name of the file it's appended to.

Format: ### FOOTER for page <FILENAME>